### PR TITLE
return theme without putting it in a list

### DIFF
--- a/R/theme_fira.R
+++ b/R/theme_fira.R
@@ -25,7 +25,7 @@
 #' @export
 theme_fira <- function(family = "Fira Sans") {
   if (!fontsReady()) setupFont()
-  list(ggplot2::`%+replace%`(
+  ggplot2::`%+replace%`(
     ggplot2::theme_grey(base_size = 11.5, base_family = family),
     ggplot2::theme(
       # add padding to the plot
@@ -77,7 +77,7 @@ theme_fira <- function(family = "Fira Sans") {
                                                                   10, 10, 
                                                                   "pt"))
     )
-  ))
+  )
 }
 
 


### PR DESCRIPTION
Great theme!

Is there a specific reason for wrapping the theme in a list?

To modify the theme, you currently need to extract it first. eg:

```
theme_fira_custom <- function(..., base_size = 8) {
    theme_fira()[[1]] %+replace% 
        theme(plot.title = element_text(hjust = 0,
                                        size = 12, colour = "#454545",
                                        margin = margin(b = 3))
    )           
}
```